### PR TITLE
Install node 20 from nodesource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,10 @@ ARG USERNAME=cheriot
 
 RUN apt update \
     && apt upgrade -y \
-    && apt install -y software-properties-common \
+    && apt install -y software-properties-common ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && add-apt-repository ppa:xmake-io/xmake \
     && apt update \
     && apt install -y xmake git bsdmainutils


### PR DESCRIPTION
The default from ubuntu too old for microvium.
Leave it up to the user to install on demand if required.