### PR TITLE
This adds building and installing mpact_cheriot simulator.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,12 @@ RUN cp obj_dir/Vswci_vtb /cheriot_ibex_safe_sim_trace
 
 FROM ubuntu:24.04 AS mpact-build
 RUN apt update && apt install -y wget git clang default-jre
-RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.21.0/bazelisk-linux-amd64
-RUN chmod a+x bazelisk-linux-amd64
-RUN mv bazelisk-linux-amd64 /usr/bin/bazel
+
+RUN machine=$(uname -m) \
+    && if [ "$machine" = "x86_64" ]; then bazel="linux-amd64" ; else bazel="darwin-arm64" ; fi \
+    && wget https://github.com/bazelbuild/bazelisk/releases/download/v1.21.0/bazelisk-$bazel \
+    && chmod a+x bazelisk-$bazel \
+    && mv bazelisk-$bazel /usr/bin/bazel
 RUN git clone https://github.com/google/mpact-cheriot.git
 WORKDIR mpact-cheriot
 RUN bazel build cheriot:mpact_cheriot

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN machine=$(uname -m) \
     && mv bazelisk-linux-$bazel /usr/bin/bazel
 RUN git clone https://github.com/google/mpact-cheriot.git
 WORKDIR mpact-cheriot
-RUN bazel build cheriot:mpact_cheriot
+RUN if [ "$machine" = "x86_64" ]; then cpu=""; else cpu="--cpu=darwin_arm64_cpu"; fi \
+    && bazel build $cpu cheriot:mpact_cheriot
 
 FROM ubuntu:24.04
 ARG USERNAME=cheriot

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN apt update \
 RUN python3 -m pip install --break-system-packages --pre git+https://github.com/makerdiary/uf2utils.git@main
 
 # Create the user
-RUN useradd -m $USERNAME -o -u 1000 -g 1000 -U \
+RUN useradd -m $USERNAME -o -u 1000 -g 1000 \
     # Add sudo support.
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,7 @@ RUN machine=$(uname -m) \
     && mv bazelisk-linux-$bazel /usr/bin/bazel \
     && git clone https://github.com/google/mpact-cheriot.git
 WORKDIR mpact-cheriot
-RUN machine=$(uname -m) \
-    && if [ "$machine" = "x86_64" ]; then cpu=""; else cpu="--cpu=aarch64"; fi \
-    && bazel build $cpu cheriot:mpact_cheriot
+RUN bazel build cheriot:mpact_cheriot
 
 FROM ubuntu:24.04
 ARG USERNAME=cheriot

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,10 @@ FROM ubuntu:24.04 AS mpact-build
 RUN apt update && apt install -y wget git clang default-jre
 
 RUN machine=$(uname -m) \
-    && if [ "$machine" = "x86_64" ]; then bazel="linux-amd64" ; else bazel="darwin-arm64" ; fi \
-    && wget https://github.com/bazelbuild/bazelisk/releases/download/v1.21.0/bazelisk-$bazel \
-    && chmod a+x bazelisk-$bazel \
-    && mv bazelisk-$bazel /usr/bin/bazel
+    && if [ "$machine" = "x86_64" ]; then bazel="amd64" ; else bazel="arm64" ; fi \
+    && wget https://github.com/bazelbuild/bazelisk/releases/download/v1.21.0/bazelisk-linux-$bazel \
+    && chmod a+x bazelisk-linux-$bazel \
+    && mv bazelisk-linux-$bazel /usr/bin/bazel
 RUN git clone https://github.com/google/mpact-cheriot.git
 WORKDIR mpact-cheriot
 RUN bazel build cheriot:mpact_cheriot

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,11 @@ RUN machine=$(uname -m) \
     && if [ "$machine" = "x86_64" ]; then bazel="amd64" ; else bazel="arm64" ; fi \
     && wget https://github.com/bazelbuild/bazelisk/releases/download/v1.21.0/bazelisk-linux-$bazel \
     && chmod a+x bazelisk-linux-$bazel \
-    && mv bazelisk-linux-$bazel /usr/bin/bazel
-RUN git clone https://github.com/google/mpact-cheriot.git
+    && mv bazelisk-linux-$bazel /usr/bin/bazel \
+    && git clone https://github.com/google/mpact-cheriot.git
 WORKDIR mpact-cheriot
 RUN machine=$(uname -m) \
-    && if [ "$machine" = "x86_64" ]; then cpu=""; else cpu="--cpu=darwin_arm64_cpu"; fi \
+    && if [ "$machine" = "x86_64" ]; then cpu=""; else cpu="--cpu=aarch64"; fi \
     && bazel build $cpu cheriot:mpact_cheriot
 
 FROM ubuntu:24.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,15 @@ RUN ./vgen
 RUN ./vcomp
 RUN cp obj_dir/Vswci_vtb /cheriot_ibex_safe_sim_trace
 
+FROM ubuntu:24.04 AS mpact-build
+RUN apt update && apt install -y wget git clang default-jre
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.21.0/bazelisk-linux-amd64
+RUN chmod a+x bazelisk-linux-amd64
+RUN mv bazelisk-linux-amd64 /usr/bin/bazel
+RUN git clone https://github.com/google/mpact-cheriot.git
+WORKDIR mpact-cheriot
+RUN bazel build cheriot:mpact_cheriot
+
 FROM ubuntu:24.04
 ARG USERNAME=cheriot
 
@@ -46,10 +55,10 @@ RUN apt update \
     && apt install -y xmake git bsdmainutils python3-pip
 
 # Install uf2convert (needed for Sonata) from pip
-RUN python3 -m pip install --break-system-packages --pre -U git+https://github.com/makerdiary/uf2utils.git@main
+RUN python3 -m pip install --break-system-packages --pre git+https://github.com/makerdiary/uf2utils.git@main
 
 # Create the user
-RUN useradd -m $USERNAME -o -u 1000 -g 1000 \
+RUN useradd -m $USERNAME -o -u 1000 -g 1000 -U \
     # Add sudo support.
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
@@ -68,6 +77,8 @@ COPY  --from=sail-build /install/cheriot_sim /cheriot-tools/bin/
 COPY  --from=ibex-build cheriot_ibex_safe_sim /cheriot-tools/bin/
 COPY  --from=ibex-build cheriot_ibex_safe_sim_trace /cheriot-tools/bin/
 COPY  --from=cheriot-audit /cheriot-audit/build/cheriot-audit /cheriot-tools/bin/
+# Install the mpact simulator
+COPY  --from=mpact-build /mpact-cheriot/bazel-bin/cheriot/mpact_cheriot /cheriot-tools/bin/
 # Install the LLVM tools
 RUN mkdir -p /cheriot-tools/bin
 COPY --from=llvm-download "/Build/install/bin/clang-13" "/Build/install/bin/lld" "/Build/install/bin/llvm-objcopy" "/Build/install/bin/llvm-objdump" "/Build/install/bin/clangd" "/Build/install/bin/clang-format" "/Build/install/bin/clang-tidy" /cheriot-tools/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN machine=$(uname -m) \
     && mv bazelisk-linux-$bazel /usr/bin/bazel
 RUN git clone https://github.com/google/mpact-cheriot.git
 WORKDIR mpact-cheriot
-RUN if [ "$machine" = "x86_64" ]; then cpu=""; else cpu="--cpu=darwin_arm64_cpu"; fi \
+RUN machine=$(uname -m) \
+    && if [ "$machine" = "x86_64" ]; then cpu=""; else cpu="--cpu=darwin_arm64_cpu"; fi \
     && bazel build $cpu cheriot:mpact_cheriot
 
 FROM ubuntu:24.04


### PR DESCRIPTION
This adds steps to download bazelisk and mpact_cheriot, build, and then copy the executable to /cheriot-tools/bin.

This also adds the -U option to useradd to ensure that a group named '$USERNAME' is also created.