### PR TITLE
Sonata boot stub update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN cp build/lowrisc_sonata_system_0/sim-verilator/Vtop_verilator /sonata_simula
 WORKDIR sw/cheri/sim_boot_stub
 RUN export PATH=/cheriot-tools/bin:$PATH \
     && make
-RUN cp sim_boot_stub /sonata_simulator_boot_stub
+RUN cp sim_sram_boot_stub /sonata_simulator_boot_stub
 
 FROM ubuntu:24.04
 ARG USERNAME=cheriot


### PR DESCRIPTION
This pulls in the PR from Sonata system: https://github.com/lowRISC/sonata-system/pull/361
We need a slightly different boot stub until the HyperRAM patch is integrated into CHERIoT-RTOS. The other part of this PR makes some changes to the comments in the Dockerfile.