### PR TITLE
Patch xmake 3.0.0 to fix the xmake run bug.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,10 @@ RUN apt update \
     && apt update \
     && apt install -y xmake git bsdmainutils python3-pip
 
+# Work around xmake 3.0.0 being buggy.
+COPY xmake.diff patch.sh /tmp
+RUN sh /tmp/patch.sh
+
 # Install uf2convert (needed for Sonata) from pip.
 RUN python3 -m pip install --break-system-packages --pre git+https://github.com/makerdiary/uf2utils.git@main
 

--- a/patch.sh
+++ b/patch.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+xmake --version --root | grep 'xmake v3.0.0+20250615,'
+if [ $? -eq 0 ] ; then
+	echo "Broken xmake found, patching..."
+	patch /usr/share/xmake/modules/private/action/build/build_binary.lua < /tmp/xmake.diff
+fi

--- a/xmake.diff
+++ b/xmake.diff
@@ -1,0 +1,21 @@
+@@ -28,11 +28,15 @@ function main(jobgraph, target, opt)
+     jobgraph:group(objects_group, function ()
+         build_object(jobgraph, target, opt)
+     end)
+-    if jobgraph:size() > jobsize then
+-        local link_group = target:fullname() .. "/link"
+-        jobgraph:group(link_group, function ()
+-            target_buildutils.add_linkjobs(jobgraph, target, opt)
+-        end)
++    local has_object_jobs = jobgraph:size() > jobsize
++
++    -- @note We always need the link task, even if the current target does not have any object files
++    -- https://github.com/xmake-io/xmake-repo/pull/7479#issuecomment-3007049158
++    local link_group = target:fullname() .. "/link"
++    jobgraph:group(link_group, function ()
++        target_buildutils.add_linkjobs(jobgraph, target, opt)
++    end)
++    if has_object_jobs then
+         jobgraph:add_orders(objects_group, link_group)
+     end
+ end


### PR DESCRIPTION
Patch is applied by a script that does the version check. This can be removed later once 3.0.1 is out.